### PR TITLE
Add async task limit and default to 100

### DIFF
--- a/tasks/multiresize.js
+++ b/tasks/multiresize.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('multiresize', 'Allows to create multiple resized images from an image', function() {
     var finishTask = this.async();
-    var options = this.options({quality: 100, background: 'transparent'});
+    var options = this.options({quality: 100, background: 'transparent', limit: 100});
 
     var isRetina2x = function(imagePath) {
       var i = imagePath.lastIndexOf('.');
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
       return false;
     };
 
-    async.each(this.files, function(f, nextFile) {
+    async.eachLimit(this.files, options.limit, function(f, nextFile) {
       var src, i = 0;
 
       //Ignores all but first src file


### PR DESCRIPTION
I resized a lot of images and `async` starts all of them in parallel. While this is good for performance it causes problems with a lot of processes and quits with `EMFILE`. This change limits the number of concurrent processes to 100. The number can be changed using the option `limit`. For more information see [here](http://stackoverflow.com/questions/19146194/node-js-spawn-emfile).
